### PR TITLE
activate profile navigation

### DIFF
--- a/app/controllers/index.php
+++ b/app/controllers/index.php
@@ -183,6 +183,8 @@ class IndexController extends StudipController
         global $user;
 
         PageLayout::setTitle(_('Meine Meetings'));
+        Navigation::activateItem('/profile/meetings');
+
         $this->getHelpbarContent('my');
         $this->deleteAction = PluginEngine::getURL($this->plugin, array(), 'index/my', true);
         $this->handleDeletion();


### PR DESCRIPTION
Bei uns kam folgendes Ticket rein, welches durch diese Änderung gelöst wird:

> Wenn man das Benutzerprofil offen hat, hat es oben eine Navigationsleiste, in der unter anderem "Meine Meetings" drin steht. 
>
> Wenn man auf "Meine Meetings" klickt, verschwindet die Navigationsleiste