### PR TITLE
Verify success of DFNConf meeting creation

### DIFF
--- a/Driver/DfnVc.php
+++ b/Driver/DfnVc.php
@@ -88,6 +88,11 @@ class DfnVc implements DriverInterface
         ));
         $xml = new \SimpleXMLElement($response);
         $scoIdAttributes = $xml->xpath('./sco/@sco-id');
+
+        if ((string) $xml->status->attributes()->code !== 'ok') {
+            return false;
+        }
+
         $parameters->setRemoteId((int) $scoIdAttributes[0]);
 
         // make the meeting private (participants have to be granted


### PR DESCRIPTION
DfnVc::createMeeting() now checks the return code of the API call
for sco-update/ type=meeting.

Otherwise it may happen that rooms are displayed in Stud.IP that
never have been created in the backend.
These rooms can't be deleted without touching the database because
deletion checks if the API call was successful.

Resolves #355