### PR TITLE
Disable auto-start button if recording unchecked

### DIFF
--- a/vueapp/components/MeetingAddLabelItem.vue
+++ b/vueapp/components/MeetingAddLabelItem.vue
@@ -138,7 +138,17 @@ export default {
                         }
                     }
                     return disabled;
-                default: 
+                case 'autoStartRecording':
+                    var disabled = false;
+                    if (this.feature['name'] == 'autoStartRecording') {
+                        if (this.room.features && Object.keys(this.room.features).includes('record')
+                            && JSON.parse(this.room.features.record) == false) {
+                            this.$set(this.room.features, 'autoStartRecording', 'false');
+                            disabled = true;
+                        }
+                    }
+                    return disabled;
+                default:
                     return false;
             }
         }


### PR DESCRIPTION
If recording checkbox in a room's settings is not checked,
the checkbox "allow webcam recording" already gets disabled
and unchecked.
This commit will apply the same behavior to the auto-start
recordings checkbox ("Aufzeichnung automatisch starten").

Note that this might be unwanted for some institutions
because it flips a default for new conference rooms:
Since recording is probably always disabled when creating
a new room, "Aufzeichnung automatisch starten" will now
be disalbed by default, too.

So please check with some institutions before merging.