### PR TITLE
configurable defaulf slides, fixes #349

### DIFF
--- a/Driver/BigBlueButton.php
+++ b/Driver/BigBlueButton.php
@@ -708,8 +708,10 @@ class BigBlueButton implements DriverInterface, RecordingInterface, FolderManage
             }
         }
 
-        // The default slide is now by default in place when there is no Folder is seleced, or there is no File in a selected folder.
-        if (empty($documents)) {
+        // If admin has selected the option to use studip default slides and there is no slides selected for this course!
+        $defaults_from = Driver::getGeneralConfigValue('read_default_slides_from');
+        $studip_default_sildes = !empty($defaults_from) && $defaults_from == 'studip' ? true : false;
+        if (empty($documents) && $studip_default_sildes) {
             $default_slide_url = \PluginEngine::getURL('meetingplugin', [], "api/defaultSlide/$meetingId/$token");
             $default_slide_url = strtok($default_slide_url, '?');
             if (isset($_SERVER['SERVER_NAME']) && strpos($default_slide_url, $_SERVER['SERVER_NAME']) === FALSE) {

--- a/migrations/047_add_general_config_studip_default_slides.php
+++ b/migrations/047_add_general_config_studip_default_slides.php
@@ -1,0 +1,55 @@
+<?php
+
+// require __DIR__.'/../vendor/autoload.php';
+
+class AddGeneralConfigStudipDefaultSlides extends Migration
+{
+
+    /**
+     * {@inheritdoc}
+     */
+    public function description()
+    {
+        return "add an option to choose whether the deafult sildes should be handled by StudIP or server with default value of 'studip' to general config";
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function up()
+    {
+        $general_config = null;
+        if (Config::get()->VC_GENERAL_CONFIG) {
+            $general_config = Config::get()->getValue('VC_GENERAL_CONFIG');
+            $general_config = json_decode($general_config, true);
+            if ($general_config && !isset($general_config['read_default_slides_from'])) {
+                $general_config['read_default_slides_from'] = 'studip';
+            }
+        } else {
+            $general_config['read_default_slides_from'] = 'studip';
+        }
+
+        $encoded_json = json_encode($general_config);
+        if ($encoded_json) {
+            Config::get()->store('VC_GENERAL_CONFIG', $encoded_json);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function down()
+    {
+        if (Config::get()->VC_GENERAL_CONFIG) {
+            $current_general_config = Config::get()->getValue('VC_GENERAL_CONFIG');
+            $current_general_config = json_decode($current_general_config, true);
+            if ($current_general_config && isset($current_general_config['read_default_slides_from'])) {
+                unset($current_general_config['read_default_slides_from']);
+            }
+            $encoded_json = json_encode($current_general_config);
+            if ($encoded_json) {
+                Config::get()->store('VC_GENERAL_CONFIG', $encoded_json);
+            }
+        }
+    }
+}

--- a/vueapp/views/Admin.vue
+++ b/vueapp/views/Admin.vue
@@ -31,8 +31,21 @@
                         v-model="general_config['feedback_sender_address']">
                     <translate>User-Mail</translate>
                 </label>
+
+                <label>
+                    <translate>Stud.IP für Standardfolien verwenden</translate>
+                    <br>
+                    <input type="radio"
+                        value="studip"
+                        v-model="general_config['read_default_slides_from']">
+                    <translate>Ja</translate>
+                    <input type="radio"
+                        value="server"
+                        v-model="general_config['read_default_slides_from']">
+                    <translate>Nein</translate>
+                </label>
                 
-                <StudipButton style="margin-top: 0;"
+                <StudipButton style="margin-top: 0;" :disabled="general_config['read_default_slides_from'] == 'server'"
                     @click="defaultSlideManagerShow = !defaultSlideManagerShow">
                     <translate>Standard-Folie verwalten</translate>
                 </StudipButton>


### PR DESCRIPTION
This PR fixes #349, which add a new general config in order for admins to decide which side should the defaults sildes taken from (StudIP or Server)
Using StudIP:
![Screenshot from 2022-04-11 15-08-29](https://user-images.githubusercontent.com/53179227/162746089-2e156276-9269-435a-bb81-8d28e805e722.png)
Using Server Side Slides:
![Screenshot from 2022-04-11 15-08-20](https://user-images.githubusercontent.com/53179227/162746170-9f688df8-9c2f-4509-aaba-ddb4edd1653e.png)
