### PR TITLE
action menu compatibility, fixes #422

### DIFF
--- a/app/controllers/index.php
+++ b/app/controllers/index.php
@@ -166,6 +166,14 @@ class IndexController extends MeetingsController
         if (MeetingPlugin::isCoursePublic($this->cid)) {
             $this->is_public = true;
         }
+
+        $studip_version = \StudipVersion::getStudipVersion();
+        if (empty($studip_version)) {
+            $manifest = MeetingPlugin::getMeetingManifestInfo();
+            $studip_version = isset($manifest["studipMinVersion"]) ? $manifest["studipMinVersion"] : 4;
+        }
+
+        $this->studip_version = floatval($studip_version);
     }
 
     public function config_action()

--- a/vueapp/components/StudipActionMenu.vue
+++ b/vueapp/components/StudipActionMenu.vue
@@ -1,6 +1,11 @@
 <template>
     <nav v-if="shouldCollapse" class="action-menu">
-        <a class="action-menu-icon" :title="$gettext('Aktionen')" aria-expanded="false" :aria-label="$gettext('Aktionsmenü')" href="#">
+        <button v-if="render_button_icon" class="action-menu-icon" :title="$gettext('Aktionen')" aria-expanded="false">
+            <span></span>
+            <span></span>
+            <span></span>
+        </button>
+        <a v-else class="action-menu-icon" :title="$gettext('Aktionen')" aria-expanded="false" :aria-label="$gettext('Aktionsmenü')" href="#">
             <div></div>
             <div></div>
             <div></div>
@@ -107,6 +112,10 @@ export default {
                 return true;
             }
             return Number.parseInt(this.collapseAt) <= this.items.length;
+        },
+
+        render_button_icon() {
+            return (STUDIP_VERSION != undefined && STUDIP_VERSION >= 5.2) ? true : false;
         }
     }
 }

--- a/vueapp/course_index.php
+++ b/vueapp/course_index.php
@@ -7,6 +7,7 @@
     let CID      = '<?= $cid ?>';
     let ICON_URL = '<?= Assets::url('images/icons/') ?>';
     let PLUGIN_ASSET_URL =  '<?= $plugin->getAssetsUrl() ?>';
+    <?= isset($studip_version) ? "let STUDIP_VERSION = $studip_version" : '' ?>;
 </script>
 
 <? PageLayout::addScript($this->plugin->getPluginUrl() . '/static<%= htmlWebpackPlugin.files.js[0] %>'); ?>


### PR DESCRIPTION
This PR fixes #422, in the easiest and fastest way possible to tackle the issue of action menu compatibility with StudIP 5.2

- Introducting STUDIP_VERSION constant to be used throughout the vue
- Checking that constant in StudipActionMenu component to decide whether to render the action menu icon with link or button element.